### PR TITLE
Modified how the Contour for the sensor surface is distinguished in parsing the OGP file

### DIFF
--- a/python/MetrologyData.py
+++ b/python/MetrologyData.py
@@ -202,22 +202,6 @@ class MetrologyData(object):
         win.set_title(title)
         return win
 
-    # Below applies outlier clipping as in plot_statistics
-    def resids_clip_boxplot(self, nsigma=4, yrange=None, title=None):
-        win = plot.Window()
-	dz = self.resids
-        # Trim outliers at nsigma and recompute mean and stdev.
-        mean, stdev = np.mean(dz), np.std(dz)
-        index = np.where((dz > mean-nsigma*stdev) & (dz < mean+nsigma*stdev))
-
-        plot.pylab.boxplot(dz[index])
-        plot.pylab.ylabel(r'$\mu$m')
-        plot.setAxis(yrange=yrange)
-        if title is None:
-            title = self.infile
-        win.set_title(title)
-        return win
-
     def plot_statistics(self, nsigma=4, title=None, zoffset=0):
         """
         Plot summary statistics of z-value residuals relative to the 

--- a/python/MetrologyData.py
+++ b/python/MetrologyData.py
@@ -265,10 +265,10 @@ class OgpData(MetrologyData):
 
         # Identify sensor and reference point clouds by mean y-values:
         # The sensor Contours are all in the range [0,42] and the reference
-	# point clouds are outside this range.  The test below is based
-	# on the mean y coordinates of the Contours, so the implicit 
-	# assumption is that no single Contour will cross between reference
-	# blocks.
+        # point clouds are outside this range.  The test below is based
+        # on the mean y coordinates of the Contours, so the implicit 
+        # assumption is that no single Contour will cross between reference
+        # blocks.
         yavgs = sorted([np.mean(cloud.y) for cloud in data.values()])
         ref_clouds = []
 


### PR DESCRIPTION
The only change is that the code no longer looks for the central 'Contour' in the file but instead selects the Contour(s) that scan the sensor by their mean y coordinates.  Peter T. says that the range [0,42] mm will always contain only data for the sensor surface.  This is for JIRA issue LSSTTD-546.

I see that this pull request contains what looks like the addition of code defining resids_clip_boxplot.  I did not write that code.  I am not sure why it is showing up here as new.  The code certainly belongs in MetrologyData.py.  I may have botched something when I worked on LSSTTD-480.
