### PR TITLE
LSSTTD-449:  Adding metadata to metrology data products

### DIFF
--- a/harnessed_jobs/absolute_height/v0/validator_absolute_height.py
+++ b/harnessed_jobs/absolute_height/v0/validator_absolute_height.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
 import os
-import glob
 import numpy as np
 import lcatr.schema
 import siteUtils
+import metUtils
 from MetrologyData import md_factory
 
-sensor_id = siteUtils.getUnitId()
 ccd_vendor = siteUtils.getCcdVendor()
 
-png_files = glob.glob('%(sensor_id)s_abs_height*.png'% locals())
-results = [lcatr.schema.fileref.make(x) for x in png_files]
-
-txt_files = glob.glob('%(sensor_id)s_abs_height*.txt'% locals())
-results.extend([lcatr.schema.fileref.make(x) for x in txt_files])
+producer = 'SR-MET-6'
+testtype = 'ABS_HEIGHT'
+results = metUtils.aggregate_filerefs(producer, testtype)
 
 #
 # Extract numerical results from pickled MetrologyData object, if it exists.

--- a/harnessed_jobs/absolute_height_offline/v0/validator_absolute_height_offline.py
+++ b/harnessed_jobs/absolute_height_offline/v0/validator_absolute_height_offline.py
@@ -10,8 +10,7 @@ ccd_vendor = siteUtils.getCcdVendor()
 
 producer = 'SR-MET-05'
 testtype = 'ABS_HEIGHT'
-origin = 'SLAC'
-results = metUtils.aggregate_filerefs(producer, testtype, origin)
+results = metUtils.aggregate_filerefs(producer, testtype)
 
 #
 # Extract numerical results from pickled MetrologyData object, if it exists.

--- a/harnessed_jobs/absolute_height_offline/v0/validator_absolute_height_offline.py
+++ b/harnessed_jobs/absolute_height_offline/v0/validator_absolute_height_offline.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 import os
-import glob
 import numpy as np
 import lcatr.schema
 import siteUtils
+import metUtils
 from MetrologyData import md_factory
 
-sensor_id = siteUtils.getUnitId()
 ccd_vendor = siteUtils.getCcdVendor()
 
-png_files = glob.glob('%(sensor_id)s_abs_height*.png'% locals())
-results = [lcatr.schema.fileref.make(x) for x in png_files]
-
-txt_files = glob.glob('%(sensor_id)s_abs_height*.txt'% locals())
-results.extend([lcatr.schema.fileref.make(x) for x in txt_files])
+producer = 'SR-MET-05'
+testtype = 'ABS_HEIGHT'
+origin = 'SLAC'
+results = metUtils.aggregate_filerefs(producer, testtype, origin)
 
 #
 # Extract numerical results from pickled MetrologyData object, if it exists.
@@ -29,7 +27,7 @@ if os.path.isfile(pickle_file):
     znom_residual_975 = sensorData.quantiles['0.975']
     results.append(lcatr.schema.valid(lcatr.schema.get('absolute_height'),
                                       dzdx=dzdx, dzdy=dzdy, z0=z0,
-                                      zmean=zmean, znom=znom, 
+                                      zmean=zmean, znom=znom,
                                       znom_residual_025=znom_residual_025,
                                       znom_residual_975=znom_residual_975))
 

--- a/harnessed_jobs/flatness/v0/validator_flatness.py
+++ b/harnessed_jobs/flatness/v0/validator_flatness.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python
-import glob
 import lcatr.schema
 import siteUtils
+import metUtils
 from MetrologyData import md_factory
 
-sensor_id = siteUtils.getUnitId()
-
-png_files = glob.glob('%(sensor_id)s_flatness*.png'% locals())
-results = [lcatr.schema.fileref.make(x) for x in png_files]
-
-txt_files = glob.glob('%(sensor_id)s_flatness*.txt'% locals())
-results.extend([lcatr.schema.fileref.make(x) for x in txt_files])
+producer = 'SR-MET-6'
+testtype = 'FLATNESS'
+results = metUtils.aggregate_filerefs(producer, testtype)
 
 sensorData = md_factory.load('flatness.pickle')
 results.append(lcatr.schema.valid(lcatr.schema.get('flatness'),

--- a/harnessed_jobs/flatness_offline/v0/validator_flatness_offline.py
+++ b/harnessed_jobs/flatness_offline/v0/validator_flatness_offline.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
-import glob
 import lcatr.schema
 import siteUtils
+import metUtils
 from MetrologyData import md_factory
 
-sensor_id = siteUtils.getUnitId()
-
-png_files = glob.glob('%(sensor_id)s_flatness*.png'% locals())
-results = [lcatr.schema.fileref.make(x) for x in png_files]
-
-txt_files = glob.glob('%(sensor_id)s_flatness*.txt'% locals())
-results.extend([lcatr.schema.fileref.make(x) for x in txt_files])
+producer = 'SR-MET-05'
+testtype = 'FLATNESS'
+origin = 'SLAC'
+results = metUtils.aggregate_filerefs(producer, testtype, origin)
 
 sensorData = md_factory.load('flatness.pickle')
 results.append(lcatr.schema.valid(lcatr.schema.get('flatness'),

--- a/harnessed_jobs/flatness_offline/v0/validator_flatness_offline.py
+++ b/harnessed_jobs/flatness_offline/v0/validator_flatness_offline.py
@@ -6,8 +6,7 @@ from MetrologyData import md_factory
 
 producer = 'SR-MET-05'
 testtype = 'FLATNESS'
-origin = 'SLAC'
-results = metUtils.aggregate_filerefs(producer, testtype, origin)
+results = metUtils.aggregate_filerefs(producer, testtype)
 
 sensorData = md_factory.load('flatness.pickle')
 results.append(lcatr.schema.valid(lcatr.schema.get('flatness'),

--- a/python/MetrologyData.py
+++ b/python/MetrologyData.py
@@ -191,7 +191,7 @@ class MetrologyData(object):
         for my_pos, my_z in zip(pos, self.resids):
             output.write('%.6f  %.6f  %.6f mm\n' % (my_pos[0], my_pos[1], my_z))
         output.close()
-    
+
     def resids_boxplot(self, yrange=None, title=None):
         win = plot.Window()
         plot.pylab.boxplot(self.resids)

--- a/python/absoluteHeightTask.py
+++ b/python/absoluteHeightTask.py
@@ -17,7 +17,7 @@ def absoluteHeightTask(sensor_id, infile, dtype='OGP', zoffset=0,
         #
         sensorData.set_ref_plane(XyzPlane(0, 0, 12998.))
     else:
-        raise RuntimeError("%s not supported for absolute height analysis" 
+        raise RuntimeError("%s not supported for absolute height analysis"
                            % dtype)
     #
     # Write surface height data points.
@@ -45,7 +45,7 @@ def absoluteHeightTask(sensor_id, infile, dtype='OGP', zoffset=0,
     azims = (10, 45)
     for azim in azims:
         sensorData.absolute_height_plot(azim=azim)
-        metData.plot.save('%s_abs_height_point_cloud_azim_%i.png' 
+        metData.plot.save('%s_abs_height_point_cloud_azim_%i.png'
                           % (sensor_id, azim))
 
     if pickle_file is not None:

--- a/python/flatnessTask.py
+++ b/python/flatnessTask.py
@@ -18,23 +18,24 @@ def flatnessTask(sensor_id, infile, dtype='OGP', pickle_file=None):
     # Make a histogram of residual heights.
     #
     sensorData.plot_statistics(title='Sensor Flatness, %s' % infile)
-    metData.plot.save('%s_flatness_residuals_hist.png' % sensor_id)
+    metData.plot.save('%s_flatness_hist.png' % sensor_id)
     #
     # Box and whisker plot of residual heights
     #
     sensorData.resids_boxplot()
-    metData.plot.save('%s_flatness_residuals_boxplot.png' % sensor_id)
+    metData.plot.save('%s_flatness_boxplot.png' % sensor_id)
     #
     # Quantile table
     #
-    sensorData.quantile_table(outfile='%s_flatness_quantile_table.txt' % sensor_id)
+    sensorData.quantile_table(outfile='%s_flatness_quantile_table.txt'
+                              % sensor_id)
     #
     # Surface plots
     #
     azims = (10, 45)
     for azim in azims:
         sensorData.flatness_plot(azim=azim)
-        metData.plot.save('%s_flatness_residuals_point_cloud_azim_%i.png' 
+        metData.plot.save('%s_flatness_point_cloud_azim_%i.png'
                           % (sensor_id, azim))
 
     if pickle_file is not None:

--- a/python/metUtils.py
+++ b/python/metUtils.py
@@ -5,11 +5,14 @@ import lcatr.schema
 from DataCatalog import DataCatalog
 import siteUtils
 
-def aggregate_filerefs(producer, testtype, origin, dp_mapping=None):
+def aggregate_filerefs(producer, testtype, origin=None, dp_mapping=None):
     """
     Aggregate the filerefs for the metrology data products and return
     them as a python list.
     """
+    if origin is None:
+        origin = siteUtils.getSiteName()
+
     if dp_mapping is None:
         dp_mapping = dict(BOXPLOT='boxplot',
                           HISTOGRAM='hist',


### PR DESCRIPTION
@sethdigel Please have a look at these changes.   I modified the filenames for the flatness data products, removing "_residuals" from the png files, so that the naming convention was the same as for the absolute height task and so that the code adding the metadata could be single function in metUtils.py that could be run for both.

[LSSTTD-449](https://jira.slac.stanford.edu/browse/LSSTTD-449)
