### PR TITLE
LSSTTD-854 Iteratively fit plane and remove outliers for flatness analysis

### DIFF
--- a/harnessed_jobs/flatness_ts5/v0/validator_flatness_ts5.py
+++ b/harnessed_jobs/flatness_ts5/v0/validator_flatness_ts5.py
@@ -10,8 +10,8 @@ testtype = 'FLATNESS'
 results = metUtils.aggregate_filerefs_ts5(producer, testtype)
 
 raftData = md_factory.load('flatness_ts5.pickle')
-peak_valley_95 = raftData.quantiles['0.975'] - raftData.quantiles['0.025']
-peak_valley_100 = raftData.quantiles['1.000'] - raftData.quantiles['0.000']
+peak_valley_95 = raftData.quantiles_filt['0.975'] - raftData.quantiles_filt['0.025']
+peak_valley_100 = raftData.quantiles_filt['1.000'] - raftData.quantiles_filt['0.000']
 
 # Make strings out of the quantile information
 quantiles = raftData.quantiles

--- a/harnessed_jobs/flatness_ts5_delta/v0/validator_flatness_ts5_delta.py
+++ b/harnessed_jobs/flatness_ts5_delta/v0/validator_flatness_ts5_delta.py
@@ -26,8 +26,8 @@ md = siteUtils.DataCatalogMetadata(CCD_MANU=siteUtils.getCcdVendor(),
 results.extend([lcatr.schema.fileref.make(qafile, metadata=md(DATA_PRODUCT='QA_PLOT'))])
 
 raftData = md_factory.load('flatness_ts5_delta.pickle')
-peak_valley_95 = raftData.quantiles['0.975'] - raftData.quantiles['0.025']
-peak_valley_100 = raftData.quantiles['1.000'] - raftData.quantiles['0.000']
+peak_valley_95 = raftData.quantiles_filt['0.975'] - raftData.quantiles_filt['0.025']
+peak_valley_100 = raftData.quantiles_filt['1.000'] - raftData.quantiles_filt['0.000']
 
 # Make strings out of the quantile information
 quantiles = raftData.quantiles


### PR DESCRIPTION
This modifies the flatness analysis to iteratively fit a plane to the scan data, removing outliers (>4 sigma deviation) at each iteration.  The RSA/RTM scan data from TS5 in particular typically have a few very large outliers (several hundreds of microns) plus a number of outliers at the tens of microns level.  Iteration unbiases the effects of the outliers on the fit of the plane.  After the iterative fitting, the PV100 (full residual range) and PV95 values (range between 0.025 and 0.975 quantiles) are derived from residuals filtered at the 5 sigma level, relaxing the filtering of outliers somewhat relative to the plane fits, because the distribution of residuals typically has tails longer than Gaussian.  There's nothing particularly magic about 5 sigma but for an automated analysis it is safer than using an absolute threshold.  

The quantile table reported by the analysis remains as before, i.e., based on the residuals without filtering the outliers.  The histogram of residuals now shows only the +/-5 sigma range, and overlays a Gaussian with dispersion defined by the variance of the residuals for reference.